### PR TITLE
fix(mcp): detect Claude MCP from ~/.claude.json

### DIFF
--- a/docs/ai-tools-skill-mcp-guide.md
+++ b/docs/ai-tools-skill-mcp-guide.md
@@ -161,7 +161,11 @@ claude mcp list
 claude mcp remove <server-name>
 ```
 
-**配置文件位置：** `~/.claude/` 目录下
+**配置文件位置（常见）：**
+
+- `~/.claude/settings.json`
+- `~/.claude/mcp.json`
+- `~/.claude.json`（部分版本会把 `mcpServers` 放在该文件顶层）
 
 也可以编辑 JSON 配置文件手动配置：
 

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -32,6 +32,33 @@ type Manager struct {
 
 var codexMCPSrvHeader = regexp.MustCompile(`^\s*\[\s*mcp_servers\.([^\]]+)\s*\]\s*$`)
 
+func normalizeServerKey(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func deleteByNormalizedKey(values map[string]any, name string) {
+	target := normalizeServerKey(name)
+	if target == "" {
+		return
+	}
+	for key := range values {
+		if normalizeServerKey(key) == target {
+			delete(values, key)
+		}
+	}
+}
+
+func claudeServerKey(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	if len(name) == 1 {
+		return strings.ToUpper(name)
+	}
+	return strings.ToUpper(name[:1]) + name[1:]
+}
+
 func NewManager() *Manager {
 	homeDir, _ := os.UserHomeDir()
 	return &Manager{
@@ -56,6 +83,11 @@ func (m *Manager) Install(target targets.Target, server string, options InstallO
 	if err != nil {
 		return err
 	}
+
+	if target.Name == "claude" {
+		spec.Name = claudeServerKey(spec.Name)
+	}
+
 	managed[spec.Name] = spec.Config
 	if err := writeManagedMCP(managedPath, managed); err != nil {
 		return err
@@ -95,7 +127,7 @@ func (m *Manager) Remove(target targets.Target, server string) error {
 	if err != nil {
 		return err
 	}
-	delete(managed, server)
+	deleteByNormalizedKey(managed, server)
 	if err := writeManagedMCP(managedPath, managed); err != nil {
 		return err
 	}
@@ -125,19 +157,30 @@ func (m *Manager) List(target targets.Target) ([]string, error) {
 		return nil, err
 	}
 
-	names := make([]string, 0, len(managed))
-	for key := range managed {
-		names = append(names, key)
+	preferred := map[string]string{}
+	addPreferred := func(name string) {
+		key := normalizeServerKey(name)
+		if key == "" {
+			return
+		}
+		preferred[key] = strings.TrimSpace(name)
+	}
+	addFallback := func(name string) {
+		key := normalizeServerKey(name)
+		if key == "" {
+			return
+		}
+		if _, ok := preferred[key]; ok {
+			return
+		}
+		preferred[key] = strings.TrimSpace(name)
 	}
 
 	if target.Name == "codex" {
 		codexServers, err := m.listCodexConfig()
 		if err == nil {
 			for key := range codexServers {
-				if _, ok := managed[key]; ok {
-					continue
-				}
-				names = append(names, key)
+				addPreferred(key)
 			}
 		}
 	}
@@ -146,10 +189,7 @@ func (m *Manager) List(target targets.Target) ([]string, error) {
 		claudeServers, err := m.listClaudeSettings()
 		if err == nil {
 			for key := range claudeServers {
-				if _, ok := managed[key]; ok {
-					continue
-				}
-				names = append(names, key)
+				addPreferred(key)
 			}
 		}
 	}
@@ -159,10 +199,7 @@ func (m *Manager) List(target targets.Target) ([]string, error) {
 		servers, err := m.listJSONMCPServers(path)
 		if err == nil {
 			for key := range servers {
-				if _, ok := managed[key]; ok {
-					continue
-				}
-				names = append(names, key)
+				addPreferred(key)
 			}
 		}
 	}
@@ -172,10 +209,7 @@ func (m *Manager) List(target targets.Target) ([]string, error) {
 		servers, err := m.listJSONMCPServers(path)
 		if err == nil {
 			for key := range servers {
-				if _, ok := managed[key]; ok {
-					continue
-				}
-				names = append(names, key)
+				addPreferred(key)
 			}
 		}
 	}
@@ -185,10 +219,7 @@ func (m *Manager) List(target targets.Target) ([]string, error) {
 		servers, err := m.listJSONMCPServers(path)
 		if err == nil {
 			for key := range servers {
-				if _, ok := managed[key]; ok {
-					continue
-				}
-				names = append(names, key)
+				addPreferred(key)
 			}
 		}
 	}
@@ -198,14 +229,22 @@ func (m *Manager) List(target targets.Target) ([]string, error) {
 		servers, err := m.listJSONMCPServers(path)
 		if err == nil {
 			for key := range servers {
-				if _, ok := managed[key]; ok {
-					continue
-				}
-				names = append(names, key)
+				addPreferred(key)
 			}
 		}
 	}
 
+	for key := range managed {
+		addFallback(key)
+	}
+
+	names := make([]string, 0, len(preferred))
+	for _, value := range preferred {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		names = append(names, value)
+	}
 	sort.Strings(names)
 	return names, nil
 }
@@ -505,18 +544,53 @@ func writeManagedMCP(path string, servers map[string]any) error {
 }
 
 func (m *Manager) installIntoClaudeSettings(spec BuiltinSpec) error {
-	settingsPath := filepath.Join(m.HomeDir, targets.All["claude"].Dir, "settings.json")
-	return m.installIntoJSONMCPServers(settingsPath, spec)
+	return m.installIntoJSONMCPServers(m.claudeSettingsWritePath(), spec)
 }
 
 func (m *Manager) removeFromClaudeSettings(name string) error {
-	settingsPath := filepath.Join(m.HomeDir, targets.All["claude"].Dir, "settings.json")
-	return m.removeFromJSONMCPServers(settingsPath, name)
+	return m.removeFromJSONMCPServers(m.claudeSettingsWritePath(), name)
 }
 
 func (m *Manager) listClaudeSettings() (map[string]any, error) {
-	settingsPath := filepath.Join(m.HomeDir, targets.All["claude"].Dir, "settings.json")
-	return m.listJSONMCPServers(settingsPath)
+	merged := map[string]any{}
+	seen := map[string]bool{}
+	for _, path := range m.claudeSettingsReadPaths() {
+		servers, err := m.listJSONMCPServers(path)
+		if err != nil {
+			continue
+		}
+		for key, value := range servers {
+			norm := normalizeServerKey(key)
+			if norm == "" {
+				continue
+			}
+			if seen[norm] {
+				continue
+			}
+			seen[norm] = true
+			merged[key] = value
+		}
+	}
+	return merged, nil
+}
+
+func (m *Manager) claudeSettingsReadPaths() []string {
+	claudeDir := filepath.Join(m.HomeDir, targets.All["claude"].Dir)
+	return []string{
+		filepath.Join(m.HomeDir, ".claude.json"),
+		filepath.Join(claudeDir, "mcp.json"),
+		filepath.Join(claudeDir, "settings.json"),
+	}
+}
+
+func (m *Manager) claudeSettingsWritePath() string {
+	for _, path := range m.claudeSettingsReadPaths() {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	claudeDir := filepath.Join(m.HomeDir, targets.All["claude"].Dir)
+	return filepath.Join(claudeDir, "settings.json")
 }
 
 func managedRecordPath(home string, target targets.Target) string {
@@ -544,6 +618,12 @@ func (m *Manager) installIntoJSONMCPServers(path string, spec BuiltinSpec) error
 		mcpServers = mapped
 	}
 
+	normalized := normalizeServerKey(spec.Name)
+	for key := range mcpServers {
+		if normalizeServerKey(key) == normalized && key != spec.Name {
+			delete(mcpServers, key)
+		}
+	}
 	mcpServers[spec.Name] = spec.Config
 	settings["mcpServers"] = mcpServers
 
@@ -552,7 +632,11 @@ func (m *Manager) installIntoJSONMCPServers(path string, spec BuiltinSpec) error
 		return err
 	}
 	payload = append(payload, '\n')
-	return config.SafeWrite(path, payload, 0o644)
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode()
+	}
+	return config.SafeWrite(path, payload, mode)
 }
 
 func (m *Manager) removeFromJSONMCPServers(path, name string) error {
@@ -569,7 +653,12 @@ func (m *Manager) removeFromJSONMCPServers(path, name string) error {
 	if !ok {
 		return fmt.Errorf("%s: mcpServers must be an object", filepath.Base(path))
 	}
-	delete(mcpServers, name)
+	normalized := normalizeServerKey(name)
+	for key := range mcpServers {
+		if normalizeServerKey(key) == normalized {
+			delete(mcpServers, key)
+		}
+	}
 	settings["mcpServers"] = mcpServers
 
 	payload, err := json.MarshalIndent(settings, "", "  ")
@@ -577,7 +666,11 @@ func (m *Manager) removeFromJSONMCPServers(path, name string) error {
 		return err
 	}
 	payload = append(payload, '\n')
-	return config.SafeWrite(path, payload, 0o644)
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode()
+	}
+	return config.SafeWrite(path, payload, mode)
 }
 
 func (m *Manager) listJSONMCPServers(path string) (map[string]any, error) {

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -24,6 +24,12 @@ func TestManagerInstallAndRemove(t *testing.T) {
 	if err := os.WriteFile(claudeConfigPath, seed, 0o600); err != nil {
 		t.Fatalf("write claude config seed: %v", err)
 	}
+	initialPerm := os.FileMode(0o0)
+	if info, err := os.Stat(claudeConfigPath); err != nil {
+		t.Fatalf("stat claude config: %v", err)
+	} else {
+		initialPerm = info.Mode().Perm()
+	}
 
 	if err := manager.Install(target, "context7", InstallOptions{Env: []string{"CONTEXT7_API_KEY=demo"}}); err != nil {
 		t.Fatalf("install context7: %v", err)
@@ -77,8 +83,8 @@ func TestManagerInstallAndRemove(t *testing.T) {
 	}
 	if info, err := os.Stat(claudeConfigPath); err != nil {
 		t.Fatalf("stat claude config: %v", err)
-	} else if info.Mode().Perm() != 0o600 {
-		t.Fatalf("expected claude config to remain 0600, got %v", info.Mode().Perm())
+	} else if info.Mode().Perm() != initialPerm {
+		t.Fatalf("expected claude config perms to stay %v, got %v", initialPerm, info.Mode().Perm())
 	}
 }
 

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -19,25 +19,33 @@ func TestManagerInstallAndRemove(t *testing.T) {
 
 	manager := &Manager{HomeDir: tmp}
 
+	claudeConfigPath := filepath.Join(tmp, ".claude.json")
+	seed := []byte("{\"mcpServers\":{\"Playwright\":{\"command\":\"npx\",\"args\":[\"-y\",\"@playwright/mcp@latest\"],\"env\":{}}}}\n")
+	if err := os.WriteFile(claudeConfigPath, seed, 0o600); err != nil {
+		t.Fatalf("write claude config seed: %v", err)
+	}
+
 	if err := manager.Install(target, "context7", InstallOptions{Env: []string{"CONTEXT7_API_KEY=demo"}}); err != nil {
 		t.Fatalf("install context7: %v", err)
 	}
 
-	settingsPath := filepath.Join(tmp, target.Dir, "settings.json")
-	data, err := os.ReadFile(settingsPath)
+	data, err := os.ReadFile(claudeConfigPath)
 	if err != nil {
-		t.Fatalf("read settings: %v", err)
+		t.Fatalf("read claude config: %v", err)
 	}
 	var payload map[string]any
 	if err := json.Unmarshal(data, &payload); err != nil {
-		t.Fatalf("parse settings: %v", err)
+		t.Fatalf("parse claude config: %v", err)
 	}
 
 	mcpServers, ok := payload["mcpServers"].(map[string]any)
 	if !ok {
 		t.Fatalf("mcpServers missing or invalid")
 	}
-	context7, ok := mcpServers["context7"].(map[string]any)
+	if _, ok := mcpServers["Playwright"]; !ok {
+		t.Fatalf("expected Playwright preserved")
+	}
+	context7, ok := mcpServers["Context7"].(map[string]any)
 	if !ok {
 		t.Fatalf("context7 missing")
 	}
@@ -55,17 +63,22 @@ func TestManagerInstallAndRemove(t *testing.T) {
 	if err := manager.Remove(target, "context7"); err != nil {
 		t.Fatalf("remove context7: %v", err)
 	}
-	data, err = os.ReadFile(settingsPath)
+	data, err = os.ReadFile(claudeConfigPath)
 	if err != nil {
-		t.Fatalf("read settings: %v", err)
+		t.Fatalf("read claude config: %v", err)
 	}
 	payload = nil
 	if err := json.Unmarshal(data, &payload); err != nil {
-		t.Fatalf("parse settings: %v", err)
+		t.Fatalf("parse claude config: %v", err)
 	}
 	mcpServers, _ = payload["mcpServers"].(map[string]any)
-	if _, exists := mcpServers["context7"]; exists {
+	if _, exists := mcpServers["Context7"]; exists {
 		t.Fatalf("expected context7 removed")
+	}
+	if info, err := os.Stat(claudeConfigPath); err != nil {
+		t.Fatalf("stat claude config: %v", err)
+	} else if info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected claude config to remain 0600, got %v", info.Mode().Perm())
 	}
 }
 
@@ -255,6 +268,48 @@ func TestManagerInstallAndRemoveUpdatesCursorMCPConfig(t *testing.T) {
 	mcpServers, _ = payload["mcpServers"].(map[string]any)
 	if _, exists := mcpServers["context7"]; exists {
 		t.Fatalf("expected context7 removed")
+	}
+}
+
+func TestManagerListClaudeMergesClaudeJSONAndSettings(t *testing.T) {
+	tmp := t.TempDir()
+	target, ok := targets.Lookup("claude")
+	if !ok {
+		t.Fatalf("expected claude target")
+	}
+
+	manager := &Manager{HomeDir: tmp}
+
+	claudeConfigPath := filepath.Join(tmp, ".claude.json")
+	if err := os.WriteFile(claudeConfigPath, []byte("{\"mcpServers\":{\"Context7\":{},\"Playwright\":{}}}\n"), 0o600); err != nil {
+		t.Fatalf("write .claude.json: %v", err)
+	}
+	settingsPath := filepath.Join(tmp, target.Dir, "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("mkdir settings dir: %v", err)
+	}
+	if err := os.WriteFile(settingsPath, []byte("{\"mcpServers\":{\"filesystem\":{}}}\n"), 0o644); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+
+	managedPath := filepath.Join(tmp, target.Dir, "mcp.json")
+	if err := os.WriteFile(managedPath, []byte("{\"mcpServers\":{\"context7\":{}}}\n"), 0o644); err != nil {
+		t.Fatalf("write managed mcp: %v", err)
+	}
+
+	names, err := manager.List(target)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	joined := strings.Join(names, ",")
+	if !strings.Contains(joined, "Context7") {
+		t.Fatalf("expected Context7 present, got %v", names)
+	}
+	if strings.Contains(joined, "context7") {
+		t.Fatalf("expected no context7 duplicate, got %v", names)
+	}
+	if !strings.Contains(strings.ToLower(joined), "filesystem") {
+		t.Fatalf("expected filesystem present, got %v", names)
 	}
 }
 


### PR DESCRIPTION
问题：Claude Code 的 MCP 实际可能存放在 `~/.claude.json` 顶层 `mcpServers`（你的机器上就是这样），但 AgentFlow 之前只读写 `~/.claude/settings.json`，导致 `agentflow mcp list claude` / TUI 看不到已有 MCP。

修复：
- Claude `list` 合并读取：`~/.claude.json`、`~/.claude/mcp.json`、`~/.claude/settings.json`
- Claude `install/remove` 优先写入已存在的那份配置（并保持原文件权限，如 0600）
- JSON MCP 操作统一按 key 大小写不敏感去重/删除
- 文档补充 Claude MCP 配置文件常见位置

测试：go test ./...